### PR TITLE
Improve indentation of multiline string

### DIFF
--- a/jbang/opensearch-search-log/os-search-log.yaml
+++ b/jbang/opensearch-search-log/os-search-log.yaml
@@ -23,12 +23,12 @@
         clusterName: "opensearch-cluster"
         indexName: "test_index"
         query: '{
-    "query": {
-      "match": {
-        "id": "1"
-      }
-    }
-  }'
+          "query": {
+            "match": {
+              "id": "1"
+            }
+          }
+         }'
       steps:
       - to: 
           uri: "kamelet:log-sink"


### PR DESCRIPTION
Several parsers are not accepting the notation and reporting validation error (for instance in VS Code).
Camel is more tolerant and was allowing it.

before:
![image](https://github.com/apache/camel-kamelets-examples/assets/1105127/bde880d9-9258-4025-b38d-d25cf0b657e2)

after:
![image](https://github.com/apache/camel-kamelets-examples/assets/1105127/3ce18571-ab46-4e63-964f-a49811433a97)
